### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: libesmtp
 Section: libs
 Priority: optional
 Maintainer: Jeremy T. Bouse <jbouse@debian.org>
-Build-Depends: debhelper (>> 12.0.0),
+Build-Depends: debhelper,
 	libltdl3-dev,
 	libssl-dev,
 	python3-pkgconfig,


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/libesmtp/a3758cc0-5ea7-4e08-aa0e-58d6e9251a4f.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/a3758cc0-5ea7-4e08-aa0e-58d6e9251a4f/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/a3758cc0-5ea7-4e08-aa0e-58d6e9251a4f/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/a3758cc0-5ea7-4e08-aa0e-58d6e9251a4f/diffoscope)).
