### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends: debhelper-compat (=13),
 	pkg-config,
 	meson,
 	ninja-build
-Standards-Version: 4.6.0
+Standards-Version: 4.6.1
 Homepage: https://libesmtp.github.io/
 Vcs-Git: https://github.com/jbouse-debian/libesmtp.git
 Vcs-Browser: https://github.com/jbouse-debian/libesmtp

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+---
+Bug-Database: https://github.com/libesmtp/libESMTP/issues
+Bug-Submit: https://github.com/libesmtp/libESMTP/issues/new
+Repository-Browse: https://github.com/libesmtp/libESMTP


### PR DESCRIPTION
Fix some issues reported by lintian

* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking))

* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes). For more information, including instructions on how to disable these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts or close the merge proposal when all changes are applied through other means (e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at https://janitor.debian.net/lintian-fixes/pkg/libesmtp/5c79747c-1243-482b-b83a-8634aea5bdf6.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/5c79747c-1243-482b-b83a-8634aea5bdf6/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/5c79747c-1243-482b-b83a-8634aea5bdf6/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/5c79747c-1243-482b-b83a-8634aea5bdf6/diffoscope)).
